### PR TITLE
fix: disable pointer-events on close

### DIFF
--- a/widget/src/chat/index.tsx
+++ b/widget/src/chat/index.tsx
@@ -149,6 +149,7 @@ const App = forwardRef<
           transformOrigin: transformOrigin,
           opacity: isOpen ? 1 : 0,
           transform: isOpen ? "scale(1)" : "scale(0)",
+          pointerEvents: isOpen ? "auto" : "none",
         }}
         src={props.iframeUrl}
         allow="clipboard-write"


### PR DESCRIPTION
This adds the pointerEvents: isOpen ? "auto" : "none" style property to the chat iframe which prevents users from accidentally interacting with the chat widget when it's closed (scaled to 0 and invisible).